### PR TITLE
feat(news): two-level LLM content structuring (takeaways + brief)

### DIFF
--- a/src/code_review_agent/news/models.py
+++ b/src/code_review_agent/news/models.py
@@ -37,6 +37,8 @@ class Article(BaseModel, frozen=True):
     is_read: bool = False
     is_saved: bool = False
     read_position: float = 0.0
+    key_takeaways: str = ""
+    structured_brief: str = ""
 
     @property
     def priority(self) -> ArticlePriority:

--- a/src/code_review_agent/news/navigator.py
+++ b/src/code_review_agent/news/navigator.py
@@ -65,6 +65,9 @@ class NewsViewer:
 
     def toggle_detail(self) -> None:
         self.is_detail_open = not self.is_detail_open
+        # Generate takeaways on first detail open (if not cached)
+        if self.is_detail_open:
+            self._ensure_takeaways()
 
     def toggle_select(self) -> None:
         """Toggle multi-select on current article (Space key)."""
@@ -235,6 +238,50 @@ class NewsViewer:
         self.selected.clear()
         self.status_message = f"Search '{query}': {len(self.articles)} matches"
 
+    def _ensure_takeaways(self) -> None:
+        """Generate takeaways for current article if not cached."""
+        if not self.articles:
+            return
+        article = self.articles[self.cursor]
+        if article.key_takeaways:
+            return  # already cached
+
+        content = article.content_text or article.summary
+        if not content:
+            return
+
+        try:
+            from code_review_agent.news.summarizer import (
+                extract_takeaways,
+                fallback_takeaways,
+                format_takeaways,
+            )
+
+            # Try LLM extraction
+            try:
+                from code_review_agent.config import Settings
+                from code_review_agent.llm_client import LLMClient
+
+                settings = Settings()
+                llm = LLMClient(settings)
+                takeaways = extract_takeaways(content, llm)
+            except Exception:
+                takeaways = []
+
+            # Fallback to first sentences
+            if not takeaways:
+                takeaways = fallback_takeaways(content)
+
+            if takeaways:
+                formatted = format_takeaways(takeaways)
+                self.articles[self.cursor] = article.model_copy(
+                    update={"key_takeaways": formatted},
+                )
+                if self.store:
+                    self.store.update_takeaways(article.id, formatted)
+        except Exception:  # noqa: S110
+            pass
+
     def open_in_browser(self) -> None:
         if not self.articles:
             return
@@ -383,7 +430,7 @@ def _render(viewer: NewsViewer) -> FormattedText:
 
 
 def _render_detail(article: Article, tw: int) -> _Lines:
-    """Enhanced detail panel: summary, comments, convergence."""
+    """Enhanced detail panel with key takeaways."""
     lines: _Lines = []
     sep = "=" * min(tw - 6, 70)
     wrap_w = max(40, tw - 10)
@@ -408,16 +455,24 @@ def _render_detail(article: Article, tw: int) -> _Lines:
     if article.tags:
         lines.append((_STYLE_MUTED, f"   Tags: {', '.join(article.tags)}\n"))
 
-    # Summary section
-    text = article.summary or article.content_text
-    if text:
+    # Key takeaways (LLM-generated, cached)
+    if article.key_takeaways:
         lines.append(("", "\n"))
-        lines.append(("bold underline", "   SUMMARY\n"))
-        # Split on pipe delimiter from pipeline enrichment
-        summary = text.split(" | Top comment:")[0] if " | Top comment:" in text else text
-        for line in summary.splitlines()[:6]:
-            for w in textwrap.wrap(line, width=wrap_w) or [""]:
-                lines.append(("", f"   {w}\n"))
+        lines.append(("bold underline", "   KEY TAKEAWAYS\n"))
+        for bullet in article.key_takeaways.splitlines():
+            if bullet.strip():
+                for w in textwrap.wrap(bullet.strip(), width=wrap_w) or [""]:
+                    lines.append(("", f"   {w}\n"))
+    else:
+        # Fallback: show summary
+        text = article.summary or article.content_text
+        if text:
+            lines.append(("", "\n"))
+            lines.append(("bold underline", "   SUMMARY\n"))
+            summary = text.split(" | Top comment:")[0] if " | Top comment:" in text else text
+            for line in summary.splitlines()[:5]:
+                for w in textwrap.wrap(line, width=wrap_w) or [""]:
+                    lines.append(("", f"   {w}\n"))
 
     # Top community comment
     top_comment = ""
@@ -429,10 +484,10 @@ def _render_detail(article: Article, tw: int) -> _Lines:
         for w in textwrap.wrap(f'"{top_comment}"', width=wrap_w) or [""]:
             lines.append(("italic", f"   {w}\n"))
 
-    # Source
+    # Source + actions
     lines.append(("", "\n"))
     lines.append((_STYLE_ACCENT, f"   Source: {article.url}\n"))
-    lines.append((_STYLE_MUTED, "   [r] read full | [o] browser | [s] save | [n] next\n"))
+    lines.append((_STYLE_MUTED, "   [r] read structured brief | [o] browser | [s] save\n"))
 
     return lines
 

--- a/src/code_review_agent/news/reader.py
+++ b/src/code_review_agent/news/reader.py
@@ -54,19 +54,26 @@ class ArticleReader:
         self._fetch_content()
 
     def _fetch_content(self) -> None:
-        """Fetch and cache article content."""
+        """Fetch content. Uses structured brief if cached, else raw content."""
         from code_review_agent.news.content import is_valid_content
 
         a = self.article
 
-        # Use cached content if valid
+        # Priority 1: Use cached structured brief
+        if a.structured_brief:
+            self.content_lines = a.structured_brief.splitlines()
+            self.is_loading = False
+            self._restore_position()
+            return
+
+        # Priority 2: Use cached raw content
         if a.content_text and is_valid_content(a.content_text):
             self.content_lines = a.content_text.splitlines()
             self.is_loading = False
             self._restore_position()
             return
 
-        # Cached content is garbled or missing -- fetch fresh
+        # Priority 3: Fetch fresh content
         try:
             from code_review_agent.news.content import fetch_article_content
 
@@ -84,6 +91,37 @@ class ArticleReader:
             self._use_fallback()
         self.is_loading = False
         self._restore_position()
+
+    def _generate_brief(self, raw_content: str) -> str:
+        """Generate structured brief via LLM. Returns empty on failure."""
+        try:
+            from code_review_agent.config import Settings
+            from code_review_agent.llm_client import LLMClient
+            from code_review_agent.news.summarizer import (
+                fallback_brief,
+                generate_structured_brief,
+            )
+
+            settings = Settings()
+            llm = LLMClient(settings)
+            brief = generate_structured_brief(raw_content, llm)
+            if brief:
+                # Cache the brief
+                if self.store:
+                    self.store.update_structured_brief(self.article.id, brief)
+                self.article = self.article.model_copy(
+                    update={"structured_brief": brief},
+                )
+                return brief
+        except Exception:  # noqa: S110
+            pass
+        # Fallback: basic paragraphing
+        try:
+            from code_review_agent.news.summarizer import fallback_brief
+
+            return fallback_brief(raw_content)
+        except Exception:
+            return ""
 
     def _use_fallback(self) -> None:
         lines = (self.article.summary or "").splitlines()
@@ -300,6 +338,16 @@ def run_article_reader(
     @kb.add(Keys.ScrollDown)
     def _sd(_e: KeyPressEvent) -> None:
         reader.scroll_down(3)
+
+    @kb.add("B")
+    def _gen_brief(_e: KeyPressEvent) -> None:
+        """Generate structured brief via LLM."""
+        brief = reader._generate_brief(
+            reader.article.content_text or reader.article.summary or "",
+        )
+        if brief:
+            reader.content_lines = brief.splitlines()
+            reader.scroll_offset = 0
 
     @kb.add("q")
     @kb.add("escape")

--- a/src/code_review_agent/news/storage.py
+++ b/src/code_review_agent/news/storage.py
@@ -33,7 +33,9 @@ CREATE TABLE IF NOT EXISTS articles (
     content_text TEXT DEFAULT '',
     is_read INTEGER DEFAULT 0,
     is_saved INTEGER DEFAULT 0,
-    read_position REAL DEFAULT 0.0
+    read_position REAL DEFAULT 0.0,
+    key_takeaways TEXT DEFAULT '',
+    structured_brief TEXT DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_articles_domain ON articles(domain);
 CREATE INDEX IF NOT EXISTS idx_articles_saved ON articles(is_saved);
@@ -56,6 +58,16 @@ class ArticleStore:
     def _init_schema(self) -> None:
         with self._get_connection() as conn:
             conn.executescript(_SCHEMA)
+            # Migrate: add columns if missing (existing DBs)
+            self._migrate_add_column(conn, "key_takeaways", "TEXT DEFAULT ''")
+            self._migrate_add_column(conn, "structured_brief", "TEXT DEFAULT ''")
+
+    @staticmethod
+    def _migrate_add_column(conn: sqlite3.Connection, col: str, col_type: str) -> None:
+        try:
+            conn.execute(f"SELECT {col} FROM articles LIMIT 1")  # noqa: S608
+        except sqlite3.OperationalError:
+            conn.execute(f"ALTER TABLE articles ADD COLUMN {col} {col_type}")
 
     def save_articles(self, articles: list[Article]) -> int:
         """Upsert articles. Returns count of inserted/updated."""
@@ -139,6 +151,22 @@ class ArticleStore:
             conn.execute(
                 "UPDATE articles SET content_html = ?, content_text = ? WHERE id = ?",
                 (html, text, article_id),
+            )
+
+    def update_takeaways(self, article_id: str, takeaways: str) -> None:
+        """Cache extracted key takeaways for an article."""
+        with self._get_connection() as conn:
+            conn.execute(
+                "UPDATE articles SET key_takeaways = ? WHERE id = ?",
+                (takeaways, article_id),
+            )
+
+    def update_structured_brief(self, article_id: str, brief: str) -> None:
+        """Cache the LLM-structured reading brief for an article."""
+        with self._get_connection() as conn:
+            conn.execute(
+                "UPDATE articles SET structured_brief = ? WHERE id = ?",
+                (brief, article_id),
             )
 
     def delete_article(self, article_id: str) -> None:
@@ -280,4 +308,6 @@ class ArticleStore:
             is_read=bool(row["is_read"]),
             is_saved=bool(row["is_saved"]),
             read_position=row["read_position"],
+            key_takeaways=row["key_takeaways"] or "",
+            structured_brief=row["structured_brief"] or "",
         )

--- a/src/code_review_agent/news/summarizer.py
+++ b/src/code_review_agent/news/summarizer.py
@@ -1,0 +1,176 @@
+"""Two-level LLM content summarization for news articles.
+
+Level 1: Key takeaways (2-5 bullets for detail panel)
+Level 2: Structured reading brief (2-5 min read for reader)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from code_review_agent.llm_client import LLMClient
+
+logger = structlog.get_logger(__name__)
+
+_MAX_INPUT_CHARS = 12000  # ~3000 tokens
+
+# --- Level 1: Key Takeaways ---
+
+_TAKEAWAY_SYSTEM = """\
+You are a news analyst. Extract the 2-5 most important takeaways \
+from this article. Each takeaway must be:
+- A single concrete insight (not generic filler)
+- Include specific data points when available (numbers, quotes, names)
+- Max 2 lines of text
+- Ordered by importance (most impactful first)
+- Strictly based on the article content (never invent facts)"""
+
+_TAKEAWAY_USER = """\
+Extract key takeaways from this article:
+
+{content}"""
+
+
+class TakeawayResponse(BaseModel, frozen=True):
+    """LLM response for key takeaway extraction."""
+
+    takeaways: list[str] = Field(default_factory=list)
+
+
+def extract_takeaways(
+    content: str,
+    llm_client: LLMClient,
+) -> list[str]:
+    """Extract 2-5 key takeaways from article content."""
+    if not content or len(content) < 50:
+        return []
+
+    truncated = content[:_MAX_INPUT_CHARS]
+    user_prompt = _TAKEAWAY_USER.format(content=truncated)
+
+    try:
+        response = llm_client.complete(
+            system_prompt=_TAKEAWAY_SYSTEM,
+            user_prompt=user_prompt,
+            response_model=TakeawayResponse,
+        )
+        takeaways = [t.strip() for t in response.takeaways if t.strip()][:5]
+        logger.debug("takeaways_extracted", count=len(takeaways))
+        return takeaways
+    except Exception:
+        logger.debug("takeaway_extraction_failed", exc_info=True)
+        return []
+
+
+def format_takeaways(takeaways: list[str]) -> str:
+    """Format takeaways as bullet points for display."""
+    if not takeaways:
+        return ""
+    lines = []
+    for t in takeaways:
+        lines.append(f"  * {t}")
+    return "\n".join(lines)
+
+
+def fallback_takeaways(content: str, count: int = 5) -> list[str]:
+    """Extract first N sentences as fallback when LLM unavailable."""
+    if not content:
+        return []
+    sentences: list[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or len(stripped) < 20:
+            continue
+        sentences.append(stripped)
+        if len(sentences) >= count:
+            break
+    return sentences
+
+
+# --- Level 2: Structured Brief ---
+
+_BRIEF_SYSTEM = """\
+You are a senior tech editor restructuring articles for busy \
+professionals. Create a well-organized 2-5 minute reading brief.
+
+Structure rules:
+1. Start with a clear ## heading for the topic
+2. Use 3-5 sections with ## headings (problem/context, findings, implications)
+3. Preserve ALL key quotes as > blockquotes with attribution
+4. Preserve ALL statistics, numbers, and data points verbatim
+5. Use **bold** for key terms and emphasis
+6. Target 800-1500 words
+7. End with "Discussion Highlights" section if community comments available
+8. End with numbered source links
+
+Quality rules:
+- Never invent facts not in the source
+- Never add personal opinion or speculation
+- Preserve the author's voice in quotes
+- Use active voice and short paragraphs (max 3-4 sentences each)"""
+
+_BRIEF_USER = """\
+Restructure this article into a well-organized reading brief:
+
+{content}"""
+
+
+class BriefResponse(BaseModel, frozen=True):
+    """LLM response for structured brief."""
+
+    brief: str = ""
+
+
+def generate_structured_brief(
+    content: str,
+    llm_client: LLMClient,
+) -> str:
+    """Generate a structured 2-5 minute reading brief."""
+    if not content or len(content) < 50:
+        return ""
+
+    truncated = content[:_MAX_INPUT_CHARS]
+    user_prompt = _BRIEF_USER.format(content=truncated)
+
+    try:
+        response = llm_client.complete(
+            system_prompt=_BRIEF_SYSTEM,
+            user_prompt=user_prompt,
+            response_model=BriefResponse,
+        )
+        brief = response.brief.strip()
+        logger.debug(
+            "brief_generated",
+            word_count=len(brief.split()),
+        )
+        return brief
+    except Exception:
+        logger.debug("brief_generation_failed", exc_info=True)
+        return ""
+
+
+def fallback_brief(content: str) -> str:
+    """Basic auto-paragraphing fallback when LLM unavailable."""
+    if not content:
+        return ""
+    lines: list[str] = []
+    current_para: list[str] = []
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if current_para:
+                lines.append(" ".join(current_para))
+                lines.append("")
+                current_para = []
+            continue
+        current_para.append(stripped)
+
+    if current_para:
+        lines.append(" ".join(current_para))
+
+    return "\n".join(lines)

--- a/tests/test_news_summarizer.py
+++ b/tests/test_news_summarizer.py
@@ -1,0 +1,169 @@
+"""Tests for two-level LLM content summarization."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from code_review_agent.news.summarizer import (
+    BriefResponse,
+    TakeawayResponse,
+    extract_takeaways,
+    fallback_brief,
+    fallback_takeaways,
+    format_takeaways,
+    generate_structured_brief,
+)
+
+
+class TestTakeawayExtraction:
+    def test_returns_takeaways(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.complete.return_value = TakeawayResponse(
+            takeaways=["Point 1", "Point 2", "Point 3"],
+        )
+        result = extract_takeaways(
+            "A long article about AI trends and technology in 2026.", mock_llm
+        )
+        assert len(result) == 3
+        assert result[0] == "Point 1"
+
+    def test_max_5_takeaways(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.complete.return_value = TakeawayResponse(
+            takeaways=[f"Point {i}" for i in range(10)],
+        )
+        result = extract_takeaways(
+            "A long article about AI with many interesting details.", mock_llm
+        )
+        assert len(result) <= 5
+
+    def test_empty_content_returns_empty(self) -> None:
+        mock_llm = MagicMock()
+        assert extract_takeaways("", mock_llm) == []
+        mock_llm.complete.assert_not_called()
+
+    def test_handles_llm_failure(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.complete.side_effect = RuntimeError("LLM down")
+        result = extract_takeaways(
+            "Some article content here with enough text for validation.",
+            mock_llm,
+        )
+        assert result == []
+
+    def test_cached_after_first_call(self) -> None:
+        """Verify the summarizer itself doesn't cache (caching is in navigator)."""
+        mock_llm = MagicMock()
+        mock_llm.complete.return_value = TakeawayResponse(takeaways=["A"])
+        long = "Article about technology trends with enough content to pass validation."
+        extract_takeaways(long, mock_llm)
+        extract_takeaways(long, mock_llm)
+        assert mock_llm.complete.call_count == 2  # no internal cache
+
+
+class TestFallbackTakeaways:
+    def test_returns_first_sentences(self) -> None:
+        content = "\n".join(f"Sentence {i} is about something important." for i in range(10))
+        result = fallback_takeaways(content, count=3)
+        assert len(result) == 3
+
+    def test_skips_short_lines(self) -> None:
+        content = "Hi\nThis is a real sentence about something.\nOk\nAnother real sentence here."
+        result = fallback_takeaways(content)
+        assert all(len(s) >= 20 for s in result)
+
+    def test_empty_content(self) -> None:
+        assert fallback_takeaways("") == []
+
+
+class TestFormatTakeaways:
+    def test_bullet_format(self) -> None:
+        formatted = format_takeaways(["Point A", "Point B"])
+        assert "* Point A" in formatted
+        assert "* Point B" in formatted
+
+    def test_empty(self) -> None:
+        assert format_takeaways([]) == ""
+
+
+class TestStructuredBrief:
+    def test_generates_brief(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.complete.return_value = BriefResponse(
+            brief="## Topic\n\nStructured content here.\n\n## Details\n\nMore info.",
+        )
+        result = generate_structured_brief(
+            "Raw article text about important technology trends.", mock_llm
+        )
+        assert "## Topic" in result
+        assert "## Details" in result
+
+    def test_empty_content(self) -> None:
+        mock_llm = MagicMock()
+        assert generate_structured_brief("", mock_llm) == ""
+        mock_llm.complete.assert_not_called()
+
+    def test_handles_llm_failure(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.complete.side_effect = RuntimeError("fail")
+        result = generate_structured_brief(
+            "Article content about technology and AI with details.", mock_llm
+        )
+        assert result == ""
+
+
+class TestFallbackBrief:
+    def test_auto_paragraphs(self) -> None:
+        content = "Line one.\nLine two.\n\nLine three after break."
+        result = fallback_brief(content)
+        assert "Line one. Line two." in result
+        assert "\n\n" in result
+
+    def test_empty(self) -> None:
+        assert fallback_brief("") == ""
+
+
+class TestStorageNewColumns:
+    def test_takeaways_column_exists(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from code_review_agent.news.storage import ArticleStore
+
+        store = ArticleStore(db_path=Path(str(tmp_path)) / "test.db")
+        from datetime import datetime
+
+        from code_review_agent.news.models import Article
+
+        a = Article(
+            id="t:1",
+            domain="hn",
+            title="T",
+            url="u",
+            fetched_at=datetime.now(),
+        )
+        store.save_articles([a])
+        store.update_takeaways("t:1", "* Point 1\n* Point 2")
+        loaded = store.load_articles()
+        assert loaded[0].key_takeaways == "* Point 1\n* Point 2"
+
+    def test_brief_column_exists(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from code_review_agent.news.storage import ArticleStore
+
+        store = ArticleStore(db_path=Path(str(tmp_path)) / "test.db")
+        from datetime import datetime
+
+        from code_review_agent.news.models import Article
+
+        a = Article(
+            id="t:1",
+            domain="hn",
+            title="T",
+            url="u",
+            fetched_at=datetime.now(),
+        )
+        store.save_articles([a])
+        store.update_structured_brief("t:1", "## Heading\n\nContent")
+        loaded = store.load_articles()
+        assert loaded[0].structured_brief == "## Heading\n\nContent"


### PR DESCRIPTION
## Summary
- **Level 1 (Enter)**: LLM extracts 2-5 key takeaway bullets, cached in SQLite
- **Level 2 (B in reader)**: LLM restructures into organized reading brief with headings/quotes/emphasis
- Both cached after first generation, fallback to raw text when LLM unavailable
- Storage: key_takeaways + structured_brief columns with auto-migration

## How to test
```bash
python -m pytest tests/test_news_summarizer.py -xvs
python -m pytest tests/ -x -q  # 1325 passed
```